### PR TITLE
Unable to combine these flags

### DIFF
--- a/etherslurp/README.md
+++ b/etherslurp/README.md
@@ -5,7 +5,7 @@
 Check out this repo (using Go), and cd to it:
 
 ```bash
-go get -ud github.com/google/trillian-examples/etherslurp
+go get -u -d github.com/google/trillian-examples/etherslurp
 # the warning "package github.com/google/trillian-examples/etherslurp: no Go files in .../src/github.com/google/trillian-examples/etherslurp" is expected
 # All terminals need to start in this directory
 cd $GOPATH/src/github.com/google/trillian-examples/etherslurp


### PR DESCRIPTION
```
go get -ud github.com/google/trillian-examples/etherslurp
flag provided but not defined: -ud
usage: get [-d] [-f] [-fix] [-insecure] [-t] [-u] [-v] [build flags] [packages]
Run 'go help get' for details.
```
even with:
```
go version
go version go1.10.1 linux/amd64
```

Recommend:
-- Splitting `go get -u -d github.com/google/trillian-examples/etherslurp`